### PR TITLE
- Initial fixes so compiles under C++ compilers

### DIFF
--- a/include/ldl.h
+++ b/include/ldl.h
@@ -14,6 +14,11 @@
 #ifndef __LDL_H__
 #define __LDL_H__
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "GlobalOptions.h"
 
 void LDL_symbolic(qp_int n, qp_int Ap[],
@@ -68,5 +73,9 @@ qp_int LDL_valid_matrix(qp_int n,
 #define LDL_SUB_VERSION 2
 #define LDL_SUBSUB_VERSION 6
 #define LDL_VERSION LDL_VERSION_CODE(LDL_MAIN_VERSION,LDL_SUB_VERSION)
+
+#ifdef __cplusplus
+}
+#endif
 
 #endif

--- a/include/timer.h
+++ b/include/timer.h
@@ -1,6 +1,12 @@
 
 #ifndef __TIMER_H__
 #define __TIMER_H__
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 #include "GlobalOptions.h"
 
 /*! qp timers and their defintions */
@@ -65,6 +71,11 @@ void tic(qp_timer* t);
  * 
  */
 qp_real toc(qp_timer* t);
+
+#ifdef __cplusplus
+}
+#endif
+
 #endif
 /* END IFDEF __TIMER_H__ */
 

--- a/src/amd_order.c
+++ b/src/amd_order.c
@@ -89,8 +89,8 @@ GLOBAL Int AMD_order
     }
 
     /* allocate two size-n integer workspaces */
-    Len = amd_malloc (n * sizeof (Int)) ;
-    Pinv = amd_malloc (n * sizeof (Int)) ;
+    Len = (Int*) amd_malloc (n * sizeof (Int)) ;
+    Pinv = (Int*) amd_malloc (n * sizeof (Int)) ;
     mem += n ;
     mem += n ;
     if (!Len || !Pinv)
@@ -106,8 +106,8 @@ GLOBAL Int AMD_order
     {
 	/* sort the input matrix and remove duplicate entries */
 	AMD_DEBUG1 (("Matrix is jumbled\n")) ;
-	Rp = amd_malloc ((n+1) * sizeof (Int)) ;
-	Ri = amd_malloc (MAX (nz,1) * sizeof (Int)) ;
+	Rp = (Int*) amd_malloc ((n+1) * sizeof (Int)) ;
+	Ri = (Int*) amd_malloc (MAX (nz,1) * sizeof (Int)) ;
 	mem += (n+1) ;
 	mem += MAX (nz,1) ;
 	if (!Rp || !Ri)
@@ -160,7 +160,7 @@ GLOBAL Int AMD_order
     ok = ok && (slen < Int_MAX) ;	/* S[i] for Int i must be OK */
     if (ok)
     {
-	S = amd_malloc (slen * sizeof (Int)) ;
+	S = (Int*) amd_malloc (slen * sizeof (Int)) ;
     }
     AMD_DEBUG1 (("slen %g\n", (double) slen)) ;
     if (!S)


### PR DESCRIPTION
Some quick mods needed to get the runqpcpp.cpp demo file to compile with a C++ compiler (g++ 10.2.0).

Still generates litteral suffix warnings, which I didn't bother looking too much into. Just set the -Wno-literal-suffix flag to silence them.
